### PR TITLE
Add the dynamics method for Spin-LSC

### DIFF
--- a/src/Dynamics.jl
+++ b/src/Dynamics.jl
@@ -287,7 +287,7 @@ function dynamics(::QDSimUtilities.Method"HEOM", units::QDSimUtilities.Units, sy
         Utilities.check_or_insert_value(data, "time", 0:sim.dt/units.time_unit:sim.nsteps*sim.dt/units.time_unit |> collect)
         flush(data)
 
-        Hamiltonian = sys.Hamiltonian .+ diagm(sum([SpectralDensities.reorganization_energy(j) * bath.svecs[nb, :] .^ 2 for (nb, j) in enumerate(bath.Jw)])) 
+        Hamiltonian = sys.Hamiltonian .+ diagm(sum([SpectralDensities.reorganization_energy(j) * bath.svecs[nb, :] .^ 2 for (nb, j) in enumerate(bath.Jw)]))
         sys_ops = [diagm(complex(bath.svecs[nb, :])) for nb = 1:size(bath.svecs, 1)]
         ρ0 = ParseInput.parse_operator(sim_node["rho0"], sys.Hamiltonian)
 
@@ -326,7 +326,7 @@ function dynamics(::QDSimUtilities.Method"BlochRedfield", units::QDSimUtilities.
         Utilities.check_or_insert_value(data, "time", 0:sim.dt/units.time_unit:sim.nsteps*sim.dt/units.time_unit |> collect)
         flush(data)
 
-        Hamiltonian = sys.Hamiltonian .+ diagm(sum([SpectralDensities.reorganization_energy(j) * bath.svecs[nb, :] .^ 2 for (nb, j) in enumerate(bath.Jw)])) 
+        Hamiltonian = sys.Hamiltonian .+ diagm(sum([SpectralDensities.reorganization_energy(j) * bath.svecs[nb, :] .^ 2 for (nb, j) in enumerate(bath.Jw)]))
         sys_ops = [diagm(complex(bath.svecs[nb, :])) for nb = 1:size(bath.svecs, 1)]
         ρ0 = ParseInput.parse_operator(sim_node["rho0"], sys.Hamiltonian)
         @time _, ρs = BlochRedfield.propagate(; Hamiltonian, ρ0, sys_ops, Jw=bath.Jw, β=bath.β, dt=sim.dt, ntimes=sim.nsteps, extraargs=Utilities.DiffEqArgs(; reltol, abstol))
@@ -357,6 +357,98 @@ function dynamics(::QDSimUtilities.Method"Forster", units::QDSimUtilities.Units,
         Utilities.check_or_insert_value(data, "U", U)
     end
     data
+end
+
+function dynamics(::QDSimUtilities.Method"Spin-LSC", units::QDSimUtilities.Units,
+                  sys::QDSimUtilities.System, bath::QDSimUtilities.Bath,
+                  sim::QDSimUtilities.Simulation, dt_group::Union{Nothing,HDF5.Group},
+                  sim_node; dry=false)
+    if !dry
+        @info "Running a Spin-LSC calculation. Please cite:"
+        QDSimUtilities.print_citation(SpinLSC.references)
+    end
+
+    transforms = Dict{String,Type{<:SpinLSC.SWTransform}}(
+        "QTransform" => SpinLSC.QTransform,
+        "WTransform" => SpinLSC.WTransform,
+        "PTransform" => SpinLSC.PTransform)
+    solvers = Dict{String,Type{<:SpinLSC.SpinLSCSolver}}(
+        "RK4" => SpinLSC.RK4,
+        "Verlet" => SpinLSC.Verlet,
+    )
+
+    transform = get(sim_node, "SW_transform", "QTransform")
+    solver = get(sim_node, "solver", "RK4")
+    transform_group = Utilites.create_and_select_group(dt_group, "SW_transform=$transform")
+    solver_group = Utilites.create_and_select_group(transform_group, "solver=$solver")
+
+    nbins = get(sim_node, "num_bins", 1)
+    nmc = sim_node["num_mc"]
+
+    for n in 1:nbins
+        Utilities.create_and_select_group(solver_group, "bin #$n")
+    end
+
+    outgroup = sim_node["outgroup"]
+
+    if !dry
+        @info "Running with $(Threads.nthreads())"
+        isnothing(sys.ρ0) || (ρs = Vector{AbstractArray{<:Complex}}(undef, nbins))
+        U0es = Vector{AbstractArray{<:Complex}}(undef, nbins)
+        T0es = Vector{AbstractArray{<:Complex}}(undef, nbins)
+
+        time = 0:sim.dt/units.time_unit:sim.nsteps*sim.dt/units.time_unit
+        for n in 1:nbins
+            data = Utilites.create_and_select_group(solver_group, "bin #$n")
+            Utilities.check_or_insert_value(data, "num_mc", nmc)
+
+            outgrouphdf5 = Utilites.create_and_select_group(data, outgroup)
+            Utilties.check_or_insert_value(data, "dt", sim.dt / units.time_unit)
+            Utilties.check_or_insert_value(data, "time_unit", units.time_unit)
+            Utilties.check_or_insert_value(data, "time", time)
+            Utilites.check_or_insert_value(outgrouphdf5, "time", time)
+            Utilites.check_or_insert_value(outgrouphdf5, "time_unit", units.time_unit)
+            flush(data)
+
+            @info "Calculating bin $n of $nbins"
+            U0e, ρ = SpinLSC.propagate(; Hamiltonian=sys.Hamiltonian, Jw=bath.Jw,
+                                       β=bath.β, num_bath_modes=bath.num_osc,
+                                       ρ0=sys.ρ0, dt=sim.dt, ntimes=sim.nsteps,
+                                       transform=transforms[transform],
+                                       nmc=nmc, solver=solvers[solver],
+                                       verbose=true, outgroup=outgroup,
+                                       output=data)
+            isnothing(ρ) || (ρs[n] = ρ)
+            U0es[n] = U0e
+            T0es[n] = read(data["T0e"])
+        end
+
+        U0e_mean, U0e_std = QDSimUtilities.matrix_avg_std(U0es)
+        T0e_mean, T0e_std = QDSimUtilities.matrix_avg_std(T0es)
+        isnothing(sys.ρ0) || (ρ_mean, ρ_std = QDSimUtilities.matrix_avg_std(ρs))
+
+        outgrouphdf5 = Utilites.create_and_select_group(solver_group, outgroup)
+        Utilities.check_or_insert_value(solver_group, "dt", sim.dt / units.time_unit)
+        Utilities.check_or_insert_value(solver_group, "time_unit", units.time_unit)
+        Utilities.check_or_insert_value(solver_group, "time", time)
+        Utilities.check_or_insert_value(outgrouphdf5, "time", time)
+        Utilities.check_or_insert_value(outgrouphdf5, "time_unit", units.time_unit)
+
+        Utilities.check_or_insert_value(solver_group, "U0e", U0e_mean)
+        Utilities.check_or_insert_value(solver_group, "U0e_std", U0e_std)
+
+        Utilities.check_or_insert_value(solver_group, "T0e", T0e_mean)
+        Utilities.check_or_insert_value(solver_group, "T0e_std", T0e_std)
+
+        if !isnothing(sys.ρ0)
+            Utilities.check_or_insert_value(outgrouphdf5, "rho", ρ_mean)
+            Utilities.check_or_insert_value(outgrouphdf5, "rho_std", ρ_std)
+            flush(outgrouphdf5)
+        end
+
+        flush(solver_group)
+    end
+    solver_group
 end
 
 end

--- a/src/Dynamics.jl
+++ b/src/Dynamics.jl
@@ -393,6 +393,8 @@ function dynamics(::QDSimUtilities.Method"Spin-LSC", units::QDSimUtilities.Units
 
     outgroup = sim_node["outgroup"]
 
+    Hamiltonian = sys.Hamiltonian .+ diagm(sum([SpectralDensities.reorganization_energy(j) * bath.svecs[nb, :] .^ 2 for (nb, j) in enumerate(bath.Jw)]))
+
     if !dry
         @info "Running with $(Threads.nthreads()) threads."
         ρs = Vector{AbstractArray{<:Complex,3}}(undef, nbins)
@@ -413,7 +415,7 @@ function dynamics(::QDSimUtilities.Method"Spin-LSC", units::QDSimUtilities.Units
             flush(data)
 
             @info "Calculating bin $n of $nbins"
-            U0e, ρ = SpinLSC.propagate(; Hamiltonian=sys.Hamiltonian, Jw=bath.Jw,
+            U0e, ρ = SpinLSC.propagate(; Hamiltonian=Hamiltonian, Jw=bath.Jw,
                                        β=bath.β, num_bath_modes=bath.num_osc,
                                        ρ0=ρ0, dt=sim.dt, ntimes=sim.nsteps,
                                        svec=bath.svecs,

--- a/src/ParseInput.jl
+++ b/src/ParseInput.jl
@@ -214,7 +214,8 @@ function parse_bath(baths, sys, unit)
             push!(Jw, bath)
             svecs[nb, nb] = 1.0
         end
-        haskey(b, "num_osc") && (num_osc = fill(b["num_osc"], nsites))
+        haskey(baths["bath"][1], "num_osc") &&
+            (num_osc = fill(baths["bath"][1]["num_osc"], nsites))
     end
     QDSimUtilities.Bath(β, Jw,svecs,(isempty(num_osc) ? nothing : num_osc))
 end

--- a/src/ParseInput.jl
+++ b/src/ParseInput.jl
@@ -93,11 +93,6 @@ function parse_system(sys_inp, unit)
         H[end, end] = cavity_energy
         H
     end
-    ρ0 = if haskey(sys_inp, "init_rho")
-        ρ0 = read_matrix(sys_inp["init_rho"], "real")
-    else
-        nothing
-    end
 
     external_fields = if haskey(sys_inp, "external_field")
         EFs = Vector{Utilities.ExternalField}()
@@ -112,7 +107,7 @@ function parse_system(sys_inp, unit)
         nothing
     end
 
-    QDSimUtilities.System(Htype, H0, ρ0, external_fields)
+    QDSimUtilities.System(Htype, H0, external_fields)
 end
 
 """

--- a/src/QDSimUtilities.jl
+++ b/src/QDSimUtilities.jl
@@ -76,8 +76,8 @@ function matrix_avg_std(mats::Vector{<:AbstractArray{<:Complex,3}})
         diff = [ x - matmean[t,:,:] for x in getindex.(mats, t,:,:) ]
         for i = 1:d, j =1:d
             matstd[t,i,j] = complex(
-                sqrt(sum(real(getindex.(diff, i,j)).^2) / (n-1)),
-                sqrt(sum(imag(getindex.(diff, i,j)).^2) / (n-1)))
+                sqrt(sum(real(getindex.(diff, i,j)).^2) / (N-1)),
+                sqrt(sum(imag(getindex.(diff, i,j)).^2) / (N-1)))
         end
     end
 

--- a/src/QDSimUtilities.jl
+++ b/src/QDSimUtilities.jl
@@ -25,7 +25,6 @@ end
 struct System
     Htype::String
     Hamiltonian::Matrix{ComplexF64}
-    ρ0::Union{Nothing, Matrix{ComplexF64}}
     external_fields::Union{Nothing, Vector{Utilities.ExternalField}}
 end
 

--- a/src/QDSimUtilities.jl
+++ b/src/QDSimUtilities.jl
@@ -63,4 +63,25 @@ function parse_exec(exec_str::String)
     end
 end
 
+function matrix_avg_std(mats::Vector{<:AbstractArray{<:Complex,3}})
+    matmean = zeros(ComplexF64, size(mats[1]))
+    matstd = zeros(ComplexF64, size(mats[1]))
+
+    N = length(mats)
+    d = size(matmean, 2)
+
+    for t in 1:size(mats[1], 1)
+        matmean[t,:,:] = sum(getindex.(mats, t,:,:)) / N
+
+        diff = [ x - matmean[t,:,:] for x in getindex.(mats, t,:,:) ]
+        for i = 1:d, j =1:d
+            matstd[t,i,j] = complex(
+                sqrt(sum(real(getindex.(diff, i,j)).^2) / (n-1)),
+                sqrt(sum(imag(getindex.(diff, i,j)).^2) / (n-1)))
+        end
+    end
+
+    matmean, matstd
+end
+
 end


### PR DESCRIPTION
This adds the dynamics method implementation for Spin-LSC and the helper function to calculate the average and standard-deviation of U0e and friends.

This builds on top of the bath discretisation PR.